### PR TITLE
Add servlet and Jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ SDMX to RDF Data Cube converter
 mvn clean dependency:copy-dependencies
 
 mvn package
+
+To run the servlet with the built-in Jetty:
+
+mvn jetty:run
+
+http://localhost:8080/sdmx2rdf/isoc_bde15dip

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,23 @@
 					</outputDirectory>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>maven-jetty-plugin</artifactId>
+                <version>6.1.10</version>
+                <configuration>
+                    <scanIntervalSeconds>10</scanIntervalSeconds>
+                    <connectors>
+                        <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
+                            <port>8080</port>
+                            <maxIdleTime>60000</maxIdleTime>
+                        </connector>
+                    </connectors>
+                    <stopPort>9966</stopPort>
+                    <stopKey>foo</stopKey>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 
@@ -103,6 +120,20 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 		</dependency>
+
+        <!--WEB APPLICATION-->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+        </dependency>
+
+        <!--Needed to run the original (non-web) app without errors-->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+        </dependency>
 
 		<!-- SDMX SOURCE DEPENDENCY -->
 		<dependency>

--- a/src/main/java/eurostat/EurostatServlet.java
+++ b/src/main/java/eurostat/EurostatServlet.java
@@ -1,0 +1,66 @@
+package eurostat;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.HttpRequestHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Component("eurostatServlet")
+public class EurostatServlet implements HttpRequestHandler {
+
+    @Autowired
+    private ApplicationContext ctx;
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    /**
+     * Default request handler, serves a RDF from the EurostatApp stream
+     * Default data source is the ESTAT latest, can be changed to the project file with the "?file" parameter
+     */
+    @Override
+    public void handleRequest(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        // get the request
+        String requested = req.getPathInfo().substring(1);
+        if(requested.trim().isEmpty()) {
+            resp.getOutputStream().print("Please set the path.");
+        }
+
+
+
+        // get the resource
+        // defaults to URL source; if needed it can be changed to the built-in file using the "?file" request parameter
+        Resource resource = null;
+
+        if(req.getParameter("file") != null){
+            resource = ctx.getResource("classpath:eurostat_dataflows/latest");
+        } else {
+            resource = ctx.getResource("url:http://www.ec.europa.eu/eurostat/SDMX/diss-web/rest/dataflow/ESTAT/all/latest");
+        }
+
+        logger.info("Resource " + resource);
+
+        // invoke the converter
+        EurostatApp ea = ctx.getBean(EurostatApp.class);
+
+        resp.setContentType("application/rdf+xml");
+        // todo may not be needed for smaller files
+        resp.setHeader("Content-Disposition","attachment; filename=" + requested + ".rdf");
+
+        try {
+            InputStream is = resource.getInputStream();
+            ea.downloadAllIsoc(is, requested, resp.getOutputStream());
+        } catch (Exception e) {
+            logger.warn(e,e);
+        }
+    }
+}

--- a/src/main/java/sdmx2rdf/Sdmx2Rdf.java
+++ b/src/main/java/sdmx2rdf/Sdmx2Rdf.java
@@ -110,7 +110,9 @@ public class Sdmx2Rdf {
 					datasetRdf = converterFactory.convert(dataFlowBean, model);
 				}
 				while (dre.moveNextKeyable()) {
+//				    logger.info("Keyable " + dre.getCurrentKey());
 					while (dre.moveNextObservation()) {
+//					    logger.info("Observation " + dre.getCurrentObservation());
 						Observation obs = dre.getCurrentObservation();
 						// String dimensionAtObservation =
 						// dre.getCurrentDatasetHeaderBean().getDataStructureReference().getDimensionAtObservation();

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,53 @@
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" id="WebApp_ID"
+         version="2.5">
+    <!-- OLD ENV -->
+    <!-- Application name -->
+    <display-name>Sdmx2Rdf</display-name>
+
+    <!-- Short description -->
+    <description>Sdmx2Rdf web demo</description>
+
+    <!-- Servlet declaration -->
+    <servlet>
+        <servlet-name>eurostatServlet</servlet-name>
+        <servlet-class>
+            org.springframework.web.context.support.HttpRequestHandlerServlet
+        </servlet-class>
+    </servlet>
+
+    <!-- Map servlet to URL -->
+    <servlet-mapping>
+        <servlet-name>eurostatServlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <!--Spring configuration-->
+    <listener>
+        <listener-class>
+            org.springframework.web.context.request.RequestContextListener
+        </listener-class>
+    </listener>
+
+    <listener>
+        <listener-class>
+            org.springframework.web.context.ContextLoaderListener
+        </listener-class>
+    </listener>
+
+    <context-param>
+        <param-name>contextClass</param-name>
+        <param-value>
+            org.springframework.web.context.support.AnnotationConfigWebApplicationContext
+        </param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>eurostat.EurostatAppContextConfiguration</param-value>
+    </context-param>
+
+</web-app>


### PR DESCRIPTION
Start the servlet with mvn jetty:run. Sample page: http://localhost:8080/sdmx2rdf/isoc_bde15dip

The isoc in the URL can be changed. 

Right now the servlet generates a 550MB file for the link above (same as the EurostatApp), so you have to be patient. The EurostatApp.java was changed a bit to expose the filter and input/output streams.

The servlet loads the input file as a resource, so it can be used to directly load urls. The default setting is to use the URL, but it can be forced to use the built-in file by adding a "file" request parameter: http://localhost:8080/sdmx2rdf/isoc_bde15dip?file
